### PR TITLE
BIN-2024-0005: Bitcoin Related Specifications

### DIFF
--- a/2024/BIN-2024-0005.md
+++ b/2024/BIN-2024-0005.md
@@ -1,0 +1,60 @@
+| BIN-2024-0005 | Bitcoin Related Specifications
+| :------------ | :-------
+| Revision      | 000 (2024-01-25)
+| Author        | Anthony Towns `<aj@erisian.com.au>`
+| |
+| Status        | Informational
+| License       | BSD-3-Clause
+| |
+
+## Abstract
+
+This document lists some known collections of Bitcoin related specifications (aka standards, rfcs, proposals, etc).
+
+## Bitcoin-specific Specifications
+
+Specifications/standards/rfcs/proposals/etc that are (at least mostly)
+directly related to Bitcoin.
+
+| Nickname   | Description
+| :--------- | :-------
+| [BIP]      | Bitcoin Improvement Proposal
+| [SLIP]     | SatoshiLabs Improvement Proposals
+| [BOLT]     | Basis of Lightning Technology
+| [BLIP]     | Bitcoin Lightning Improvement Proposal
+| [LNPBP]    | Lightning Network Protocol / Bitcoin Protocol Standards Repository
+| [dlcspecs] | Discreet Log Contract In Progress Specifications
+| [MINT]     | Miniscript Templates
+| [BINANA]   | Bitcoin Inquisition Number And Name Authority
+
+[BINANA]: https://github.com/bitcoin-inquisition/binana/
+[BIP]: https://github.com/bitcoin/bips
+[BLIP]: https://github.com/lightning/blips
+[BOLT]: https://github.com/lightning/bolts/blob/master/00-introduction.md
+[dlcspecs]: https://github.com/discreetlogcontracts/dlcspecs/
+[LNPBP]: https://github.com/LNP-BP/LNPBPs
+[MINT]: https://github.com/Blockstream/miniscript-templates/
+[SLIP]: https://github.com/satoshilabs/slips
+
+## Other Specifications
+
+Specifications/standards/rfcs/proposals/etc that are not directly related
+to Bitcoin, but that refer to other blockchains or similar and thus likely
+have relevant ideas.
+
+| Nickname     | Description
+| :----------- | :-------
+| [EIP]        | Ethereum Improvement Proposals
+| [ERC]        | Ethereum Request For Comment
+| [BCR], [BCP] | Blockchain Commons Research, Proposals
+| [CHIPs]      | Chia Improvement Proposals
+| [Grin RFCs]  | Grin RFCS (mimblewimble)
+| [ZIPs]       | Zcash Improvement Proposals
+
+[BCR]: https://github.com/BlockchainCommons/Research
+[BCP]: https://github.com/BlockchainCommons/bcps
+[CHIPs]: https://github.com/Chia-Network/chips/
+[EIP]: https://eips.ethereum.org/
+[ERC]: https://eips.ethereum.org/erc
+[Grin RFCs]: https://github.com/mimblewimble/grin-rfcs
+[ZIPs]: https://github.com/zcash/zips

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ may be identified by appending "-RRR", the three digit revision number.
 | BIN-2024-0002 | Active     | [Heretical Deployments](2024/BIN-2024-0002.md)
 | BIN-2024-0003 | Draft      | [`CHECKSIGFROMSTACK`](2024/BIN-2024-0003.md)
 | BIN-2024-0004 | Draft      | [`OP_INTERNALKEY`](2024/BIN-2024-0004.md)
+| BIN-2024-0005 | Info       | [Bitcoin Related Specifications](2024/BIN-2024-0005.md)
 
 ## Notes
 


### PR DESCRIPTION
BINANA is certainly not the first or only repo for publishing Bitcoin related standards, so why not link to other known repos?