### PR TITLE
Syncs OP_CAT BINANA to changes in to BIP

### DIFF
--- a/2024/BIN-2024-0001.md
+++ b/2024/BIN-2024-0001.md
@@ -81,7 +81,7 @@ This implementation is inspired by the original implementation of `OP_CAT` as sh
 
 The value of `MAX_SCRIPT_ELEMENT_SIZE` is 520.
 
-This implementation is inspired by the original implementation of [https://github.com/bitcoin/bitcoin/blob/01cd2fdaf3ac6071304ceb80fb7436ac02b1059e/script.cpp#L381-L393 OP_CAT as it existed in the Bitcoin codebase] prior to the commit "misc changes" 4bd188c[^NakamotoMisc] which disabled it:
+This implementation is inspired by the original implementation of [OP_CAT as it existed in the Bitcoin codebase](https://github.com/bitcoin/bitcoin/blob/01cd2fdaf3ac6071304ceb80fb7436ac02b1059e/script.cpp#L381-L393) prior to the commit "misc changes" 4bd188c[^NakamotoMisc] which disabled it:
 
 ```c++
 case OP_CAT:
@@ -99,7 +99,7 @@ case OP_CAT:
 break;
 ```
 
-An alternative implementation of OP_CAT can be found in Elements <ref>Roose S., Elements Project, "Re-enable several disabled opcodes", 2019, https://github.com/ElementsProject/elements/commit/13e1103abe3e328c5a4e2039b51a546f8be6c60a#diff-a0337ffd7259e8c7c9a7786d6dbd420c80abfa1afdb34ebae3261109d9ae3c19R740-R759</ref>.
+An alternative implementation of `OP_CAT` can be found in Elements[^RooseElements].
 
 ## Acknowledgements
 

--- a/2024/BIN-2024-0001.md
+++ b/2024/BIN-2024-0001.md
@@ -13,14 +13,23 @@
 
 ## Abstract
 
-This BIP reintroduces `OP_CAT` in the form of a new tapscript opcode which allows the concatenation of two values on the stack. This opcode would be activated via a soft fork by redefining the opcode `OP_SUCCESS126` (126 in decimal and 0x7e in hexidecimal). This is same opcode value used by the original `OP_CAT`.
+This BIP introduces `OP_CAT` as a tapscript opcode which allows the concatenation of two values on the stack. `OP_CAT` would be activated via a soft fork by redefining the opcode `OP_SUCCESS126` (126 in decimal and 0x7e in hexadecimal). This is the same opcode value used by the original `OP_CAT`.
+
+## Copyright
+
+This document is licensed under the 3-clause BSD license.
+
+## Specification
 
 When evaluated, the `OP_CAT` instruction:
-* Pops the top two values off the stack,
-* concatenates the popped values together, and then
-* pushes the concatenated value on the top of the stack.
+1. Pops the top two values off the stack,
+2. concatenates the popped values together in stack order,
+3. and then pushes the concatenated value on the top of the stack.
 
-`OP_CAT` fails if there are less than two values on the stack or if a concatenated value would have a combined size greater than the maximum script element size of 520 bytes.
+Given the stack `[x1, x2]`, where `x2` is at the top of the stack, `OP_CAT` will push `x1 || x2` onto the stack. By `||` we denote concatenation. `OP_CAT` fails if there are fewer than two values on the stack or if a concatenated value would have a combined size greater than the maximum script element size of 520 bytes.
+`OP_CAT` pops two elements off the stack, concatenates them together in stack order, and pushes the resulting element onto the stack. 
+
+This opcode would be activated via a soft fork by redefining the tapscript opcode `OP_SUCCESS126` (126 in decimal and 0x7e in hexadecimal) to `OP_CAT`.
 
 ## Motivation
 
@@ -39,25 +48,31 @@ Bitcoin tapscript lacks a general purpose way of combining objects on the stack 
 The opcode `OP_CAT` was available in early versions of Bitcoin. However, `OP_CAT` was removed because it enabled the construction of a script whose evaluation could have memory usage exponential in the size of the script.
 For example, a script that pushed a 1-byte value on the stack and then repeated the opcodes `OP_DUP`, `OP_CAT` 40 times would result in a stack value whose size was greater than 1 terabyte. This is no longer an issue because tapscript enforces a maximum stack element size of 520 bytes.
 
-## Specification
+### Rationale
 
-`OP_CAT` pops two elements off the stack, concatenates them together in stack order, and pushes the resulting element onto the stack. Given the stack `[x1, x2]`, where `x2` is at the top of the stack, `OP_CAT` will push `x1 || x2` onto the stack. By `||` we denote concatenation.
+Our decision to reenable `OP_CAT` by redefining a tapscript `OP_SUCCESSx` opcode to `OP_CAT` was motivated to leverage the tapscript softfork opcode upgrade path introduced in [BIP342](https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki).
 
-### Implementation
+We specifically choose to use `OP_SUCCESS126` rather than another `OP_SUCCESSx` as `OP_SUCCESS126` uses the same opcode value (126 in decimal and 0x7e in hexadecimal) that was used for `OP_CAT` prior to it being disabled in Bitcoin. This removes a potential source of confusion that would exist if we had a opcode value different from the one used in the original `OP_CAT` opcode.
+
+While the `OP_SUCCESSx` opcode upgrade path could enable us to increase the stack element size while reenabling `OP_CAT`, we wanted to separate the decision to change the stack element size limit from the decision to reenable `OP_CAT`. This BIP takes no position in favor or against increasing the stack element size limit.
+
+### Backwards Compatibility
+
+`OP_CAT` usage in an non-tapscript script will continue to trigger the `SCRIPT_ERR_DISABLED_OPCODE`. The only change would be to `OP_CAT` usage in tapscript. This change to tapscript would be activated a soft fork that redefines an `OP_SUCCESSx` opcode (`OP_SUCCESS126`) to `OP_CAT`.
+
+### Reference Implementation
 
 ```c++
 case OP_CAT:
 {
-    if (stack.size() < 2) {
-        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-    }
-    valtype& vch1 = stacktop(-2);
-    valtype& vch2 = stacktop(-1);
-    if (vch1.size() + vch2.size() > MAX_SCRIPT_ELEMENT_SIZE) {
-        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-    }
-    vch1.insert(vch1.end(), vch2.begin(), vch2.end());
-    stack.pop_back();
+  if (stack.size() < 2)
+    return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+  valtype& vch1 = stacktop(-2);
+  valtype& vch2 = stacktop(-1);
+  if (vch1.size() + vch2.size() > MAX_SCRIPT_ELEMENT_SIZE)
+    return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
+  vch1.insert(vch1.end(), vch2.begin(), vch2.end());
+  stack.pop_back();
 }
 break;
 ```
@@ -66,11 +81,11 @@ This implementation is inspired by the original implementation of `OP_CAT` as sh
 
 The value of `MAX_SCRIPT_ELEMENT_SIZE` is 520.
 
-## Notes
-
-[`OP_CAT` s it existed in the Bitcoin codebase](https://github.com/bitcoin/bitcoin/blob/01cd2fdaf3ac6071304ceb80fb7436ac02b1059e/script.cpp#L381-L393) prior to the commit "misc changes" 4bd188c[^NakamotoMisc] which disabled it:
+This implementation is inspired by the original implementation of [https://github.com/bitcoin/bitcoin/blob/01cd2fdaf3ac6071304ceb80fb7436ac02b1059e/script.cpp#L381-L393 OP_CAT as it existed in the Bitcoin codebase] prior to the commit "misc changes" 4bd188c[^NakamotoMisc] which disabled it:
 
 ```c++
+case OP_CAT:
+{
   // (x1 x2 -- out)
   if (stack.size() < 2)
     return false;
@@ -80,20 +95,15 @@ The value of `MAX_SCRIPT_ELEMENT_SIZE` is 520.
   stack.pop_back();
   if (stacktop(-1).size() > 5000)
     return false;
-  }
+}
+break;
 ```
 
-## Backwards Compatibility
-
-`OP_CAT` usage in any Non-SegWitV1 script will continue to trigger the `SCRIPT_ERR_DISABLED_OPCODE`.
+An alternative implementation of OP_CAT can be found in Elements <ref>Roose S., Elements Project, "Re-enable several disabled opcodes", 2019, https://github.com/ElementsProject/elements/commit/13e1103abe3e328c5a4e2039b51a546f8be6c60a#diff-a0337ffd7259e8c7c9a7786d6dbd420c80abfa1afdb34ebae3261109d9ae3c19R740-R759</ref>.
 
 ## Acknowledgements
 
-We wish to acknowledge Dan Gould for encouraging and helping review this effort.
-
-## Copyright
-
-This document is licensed under the 3-clause BSD license.
+We wish to acknowledge Dan Gould for encouraging and helping review this effort. We also want to thank Madars Virza, Jeremy Rubin, Andrew Poelstra, Bob Summerwill for their feedback, review and helpful comments.
 
 [^PikeKernighan]: R. Pike and B. Kernighan, ["Program design in the UNIX environment", 1983](https://harmful.cat-v.org/cat-v/unix_prog_design.pdf)
 [^LinusBitStream]: R. Linus, ["BitStream: Decentralized File Hosting Incentivised via Bitcoin Payments", 2023](https://robinlinus.com/bitstream.pdf)


### PR DESCRIPTION
This commit keeps the BINANA version of OP_CAT in sync with the BIP version. There have been a few small changes that were not ported over and then today one big change. The big change is described below.

Bob Summerwill proposed a number of changes to the OP_CAT BIP to better follow BIP-2. This commit makes these changes:

* Using the section order specified in BIP-2
* Adding a Rationale section
* Expand the specification section by moving details from the abstract into the specification

Additionally this commit rewords some confusing language.