### PR TITLE
Introduce BIN-2026-0001 for BIP-446 `OP_TEMPLATEHASH`

### DIFF
--- a/2026/BIN-2026-0001.md
+++ b/2026/BIN-2026-0001.md
@@ -1,0 +1,23 @@
+| BIN-2026-0001 | `OP_TEMPLATEHASH`
+| :------------ | :----------------
+| Revision      | 000 (2026-03-18)
+| Author        | Gregory Sanders `<gsanders87@gmail.com>`
+|               | Antoine Poinsot `<mail@antoinep.com>`
+|               | Steven Roose `<steven@stevenroose.org>`
+| |
+| Layer         | Consensus (soft fork)
+| Status        | Draft
+| License       | CC0-1.0
+| |
+| Discussion    | https://gnusha.org/pi/bitcoindev/26b96fb1-d916-474a-bd23-920becc3412cn@googlegroups.com/
+| Aliases       | [BIP-446](https://github.com/bitcoin/bips/blob/69a63f629f4c27b249882b4e0db6af516f1bcea9/bip-0446.md)
+
+## Reference
+
+This document assigns BIN-2026-0001 to BIP-446.
+
+## Revisions
+
+| Revision | Commit hash | Commentary
+| :------- | :---------- | :----
+| 000      | [`2778442c21cef2290ae3e0c843d9f3179aa1cdd0`](https://github.com/bitcoin/bips/commit/2778442c21cef2290ae3e0c843d9f3179aa1cdd0/bip-0446.md) | N/A


### PR DESCRIPTION
This introduces a BIN for the `OP_TEMPLATEHASH` proposal as drafted in https://github.com/bitcoin/bips/pull/1974 and implemented in https://github.com/bitcoin-inquisition/bitcoin/pull/100.

The proposal dates from late 2025 but BIN-26-1 was chosen in place of BIN-25-4 since the BIP number 446 was assigned on February 6, 2026. Since the revision date [should match](https://github.com/bitcoin-inquisition/binana/pull/17#issuecomment-3612315701) the referenced document, i went with 26.

Since the BIP is not merged yet, we link to the PR instead of a commit hash on the author's branch, which would be much more volatile due to force pushes in addressing review comments. Once the BIP is merged, the revision will be updated to a commit hash.