### PR TITLE
Add BIN-2025-0003, OP_PAIRCOMMIT

### DIFF
--- a/2025/BIN-2025-0003.md
+++ b/2025/BIN-2025-0003.md
@@ -1,0 +1,21 @@
+| BIN-2025-0003 | `PAIRCOMMIT`
+| :------------ | :-------
+| Revision      | 000 (2026-03-24)
+| Author        | moonsettler `<moonsettler@protonmail.com>`
+|               | Brandon Black `<freedom@reardencode.com>`
+| |
+| Layer         | Consensus (soft fork)
+| Status        | Draft
+| License       | BSD-3-Clause
+| |
+| Aliases       | [BIP-442](https://github.com/bitcoin/bips/blob/6deafd07ff5d38c7d69b27530ba55a4ee038cde7/bip-0442.md)
+
+## Reference
+
+This document assigns BIN-2025-0003 to BIP-442.
+
+## Revisions
+
+| Revision | Commit hash
+| :------- | :----
+| BIN-2025-0003.000 | [6deafd07ff5d38c7d69b27530ba55a4ee038cde7](https://github.com/bitcoin/bips/blob/6deafd07ff5d38c7d69b27530ba55a4ee038cde7/bip-0442.md)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ BIN-2024-0001.003 would become BIN24-1.3.
 | BIN-2024-0005 | Complete   | [Bitcoin Related Specifications](2024/BIN-2024-0005.md)
 | BIN-2025-0001 | Draft      | [Consensus Cleanup](2025/BIN-2025-0001.md)
 | BIN-2025-0002 | Draft      | [Sharing Block Templates with Peers](2025/BIN-2025-0002.md)
+| BIN-2025-0003 | Draft      | [`OP_PAIRCOMMIT`](2025/BIN-2025-0003.md)
 | BIN-2026-0001 | Draft      | [`OP_TEMPLATEHASH`](2026/BIN-2026-0001.md)
 | BIN-2026-0002 | Draft      | [`OP_CHECKCONTRACTVERIFY`](2026/BIN-2026-0002.md)
 


### PR DESCRIPTION
This is a rebase of #17

In the interim, BIP-442 has been merged, so I updated the date to the date of the last commit in the bips repo.

Should this have a 2026 binana instead now?

Sorry, I had kind of forgotten about this...